### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/app/src/main/java/com/sevtinge/cemiuiler/module/hook/guardprovider/DisableUploadAppList.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/module/hook/guardprovider/DisableUploadAppList.java
@@ -26,7 +26,7 @@ public class DisableUploadAppList extends BaseHook {
             if (guardApplication != null) {
                 Field[] guardApplicationFields = guardApplication.getDeclaredFields();
                 for (Field field : guardApplicationFields) {
-                    if (field.getName().equals("c")) {
+                    if ("c".equals(field.getName())) {
                         XposedHelpers.setStaticBooleanField(guardApplication, "c", true);
                         XposedLogUtils.logI("Info: GuardProvider will work as debug mode!");
                     }
@@ -48,7 +48,7 @@ public class DisableUploadAppList extends BaseHook {
             final Method[] methods = antiDefraudAppManager.getDeclaredMethods();
             Method getAllUnSystemAppsStatus = null;
             for (Method method : methods) {
-                if (method.getName().equals("getAllUnSystemAppsStatus") && method.getParameterTypes().length == 1) {
+                if ("getAllUnSystemAppsStatus".equals(method.getName()) && method.getParameterTypes().length == 1) {
                     getAllUnSystemAppsStatus = method;
                     break;
                 }

--- a/app/src/main/java/com/sevtinge/cemiuiler/module/hook/securitycenter/app/AppDetails.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/module/hook/securitycenter/app/AppDetails.java
@@ -44,7 +44,7 @@ public class AppDetails extends BaseHook {
             boolean oldMethodFound = false;
 
             for (Member method : mAmAppInfoCls.getDeclaredMethods()) {
-                if (method.getName().equals("onLoadFinished")) {
+                if ("onLoadFinished".equals(method.getName())) {
                     oldMethodFound = true;
                 }
             }

--- a/app/src/main/java/com/sevtinge/cemiuiler/module/hook/various/DialogCustom.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/module/hook/various/DialogCustom.java
@@ -62,7 +62,7 @@ public class DialogCustom extends BaseHook {
         if (mAlertControllerCls != null) {
 
             for (Method method : mAlertControllerCls.getDeclaredMethods()) {
-                if (method.getName().equals("setupDialogPanel")) {
+                if ("setupDialogPanel".equals(method.getName())) {
                     oldMethodFound = true;
                     XposedLogUtils.logI(TAG, method.getName());
                 }

--- a/app/src/main/java/com/sevtinge/cemiuiler/module/hook/various/DialogGravity.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/module/hook/various/DialogGravity.java
@@ -39,7 +39,7 @@ public class DialogGravity extends BaseHook {
         if (mDialogCls != null) {
             boolean oldMethodFound = false;
             for (Method method : mDialogCls.getDeclaredMethods()) {
-                if (method.getName().equals("setupDialogPanel")) oldMethodFound = true;
+                if ("setupDialogPanel".equals(method.getName())) oldMethodFound = true;
                 methodList.add(method);
                 LogI(TAG, method.getName());
             }

--- a/app/src/main/java/com/sevtinge/cemiuiler/ui/MainActivity.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/ui/MainActivity.java
@@ -161,7 +161,7 @@ public class MainActivity extends SettingsActivity {
             else if (val instanceof Boolean)
                 path = "boolean/";
             getContentResolver().notifyChange(Uri.parse("content://" + SharedPrefsProvider.AUTHORITY + "/" + path + s), null);
-            if (!path.equals(""))
+            if (!"".equals(path))
                 getContentResolver().notifyChange(Uri.parse("content://" + SharedPrefsProvider.AUTHORITY + "/pref/" + path + s), null);
         };
 
@@ -183,7 +183,7 @@ public class MainActivity extends SettingsActivity {
 
     void findMod(String filter) {
         lastFilter = filter;
-        mSearchResultView.setVisibility(filter.equals("") ? View.GONE : View.VISIBLE);
+        mSearchResultView.setVisibility("".equals(filter) ? View.GONE : View.VISIBLE);
         ModSearchAdapter adapter = (ModSearchAdapter) mSearchResultView.getAdapter();
         if (adapter == null) return;
         adapter.getFilter().filter(filter);

--- a/app/src/main/java/com/sevtinge/cemiuiler/ui/base/BaseSettingsActivity.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/ui/base/BaseSettingsActivity.java
@@ -131,7 +131,7 @@ public class BaseSettingsActivity extends AppCompatActivity {
                     "' | grep -v $$) != \"\" ]] && { pkill -l 9 -f \"" + packageName +
                     "\"; }; } || { echo \"kill error\"; }", true, true);
                 if (commandResult.result == 0) {
-                    if (commandResult.successMsg.equals("kill error")) {
+                    if ("kill error".equals(commandResult.successMsg)) {
                         pid = false;
                     } else result = true;
                 } else

--- a/app/src/main/java/com/sevtinge/cemiuiler/ui/fragment/sub/MultiActionSettings.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/ui/fragment/sub/MultiActionSettings.java
@@ -142,9 +142,9 @@ public class MultiActionSettings extends SettingsPreferenceFragment {
 
         if (!pkgActName.equals(notSelected)) {
             if (pkgActArray.length >= 1 && pkgActArray[0] != null) try {
-                if (!forcePkg && pkgActArray.length >= 2 && pkgActArray[1] != null && !pkgActArray[1].trim().equals("")) {
+                if (!forcePkg && pkgActArray.length >= 2 && pkgActArray[1] != null && !"".equals(pkgActArray[1].trim())) {
                     return pm.getActivityInfo(new ComponentName(pkgActArray[0], pkgActArray[1]), 0).loadLabel(pm).toString();
-                } else if (!pkgActArray[0].trim().equals("")) {
+                } else if (!"".equals(pkgActArray[0].trim())) {
                     ai = pm.getApplicationInfo(pkgActArray[0], 0);
                     return pm.getApplicationLabel(ai).toString();
                 }

--- a/app/src/main/java/com/sevtinge/cemiuiler/ui/various/LocationDataActivity.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/ui/various/LocationDataActivity.java
@@ -160,7 +160,7 @@ public class LocationDataActivity extends AppCompatActivity implements View.OnCl
             builder.setView(view);
             builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
                 String n = n(editText.getText().toString());
-                if (n.equals("") || !e(n)) {
+                if ("".equals(n) || !e(n)) {
                     ToastHelper.makeText(this, "格式错误");
                     return;
                 }

--- a/app/src/main/java/com/sevtinge/cemiuiler/utils/TileUtils.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/utils/TileUtils.java
@@ -234,7 +234,7 @@ public abstract class TileUtils extends BaseHook {
     private void SystemUiHook() {
         String custom = customName();
         if (needCustom()) {
-            if (custom.equals("")) {
+            if ("".equals(custom)) {
                 XposedLogUtils.logE(TAG, "Error custom:" + custom);
                 return;
             }
@@ -349,7 +349,7 @@ public abstract class TileUtils extends BaseHook {
         if (needCustom()) {
             int customValue = customValue();
             String custom = customName();
-            if (customValue == -1 || custom.equals("")) {
+            if (customValue == -1 || "".equals(custom)) {
                 XposedLogUtils.logE(TAG, "Error customValue:" + customValue);
                 return;
             }


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [http://cwe.mitre.org/data/definitions/476.html](http://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-zc%2FCemiuiler%7C8954fe4380547f1c8c730cd591c944e5f3b59aa0)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->